### PR TITLE
Enable `check:package-version` script during CI so semver version bumps are enforced automatically

### DIFF
--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -12,12 +12,12 @@ jobs:
           bun-version: "1.1.37"
       - run: bun install --frozen-lockfile
       - run: bun run check:environment
-      # - run: bun run check:package-version
-      #   env:
-      #     GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
-      #     GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
-      #     GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
-      #     GITHUB_TOKEN: ${{ github.token }}
+      - run: bun run check:package-version
+        env:
+          GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
+          GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+          GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
+          GITHUB_TOKEN: ${{ github.token }}
       - run: bun --bun run check:formatting
       - run: bun --bun run check:lint-conflicts
       - run: bun --bun run check:types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- Enable `check:package-version` script during CI so semver version bumps are enforced automatically
+
 ## 1.0.0
 
 - First public release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/assertions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Eric L. Goldstein",
   "description": "TypeScript-based assertion functions to impose invariants",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `1.0.1`
- Enable `check:package-version` script during CI so semver version bumps are enforced automatically