### PR TITLE
Tweak assertion functions, export AssertionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0
+
+- Change `assert()`'s `condition` type from `boolean` to `unknown`
+- Change `assertNotNullish()`
+  - Add an optional `message` parameter
+  - When throwing an error, add the actual value to the error object's `cause` field
+- Export `AssertionError` (for example, can be used with `instanceof` checks in unit tests)
+
 ## 1.0.1
 
 - Enable `check:package-version` script during CI so semver version bumps are enforced automatically

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/assertions",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Eric L. Goldstein",
   "description": "TypeScript-based assertion functions to impose invariants",
   "engines": {

--- a/src/assertions.mts
+++ b/src/assertions.mts
@@ -12,7 +12,7 @@ class AssertionError extends Error {
  * @param condition Condition to impose.
  * @param message   Error message to include as part of the thrown error.
  */
-function assert(condition: boolean, message = 'Assertion condition failure'): asserts condition {
+function assert(condition: unknown, message = 'Assertion condition failure'): asserts condition {
   if (!condition) {
     throw new AssertionError(message);
   }
@@ -20,13 +20,17 @@ function assert(condition: boolean, message = 'Assertion condition failure'): as
 
 /**
  * Impose an invariant by verifying the provided value is not nullish, otherwise throw an `AssertionError`.
- * @param value Value to verify not nullish.
+ * @param value   Value to verify not nullish.
+ * @param message Error message to include as part of the thrown error.
  */
-function assertNotNullish<T>(value: T): asserts value is NonNullable<T> {
+function assertNotNullish<T>(
+  value: T,
+  message = 'Non-nullish value expected',
+): asserts value is NonNullable<T> {
   if (value === undefined || value === null) {
-    throw new AssertionError(`Expected defined value but received: ${String(value)}`);
+    throw new AssertionError(message, { cause: { value } });
   }
 }
 
 // Module Exports
-export { assert, assertNotNullish };
+export { assert, AssertionError, assertNotNullish };


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `1.1.0`
- Change `assert()`'s `condition` type from `boolean` to `unknown`
- Change `assertNotNullish()`
  - Add an optional `message` parameter
  - When throwing an error, add the actual value to the error object's `cause` field
- Export `AssertionError` (for example, can be used with `instanceof` checks in unit tests)