### PR TITLE
Add an optional 3rd parameter to  to enable customizing the thrown error's  field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0
+
+- Add an optional 3rd parameter to `assert()` to enable customizing the thrown error's `cause` field
+
 ## 1.2.0
 
 - Add a build step so library consumers can use runtimes that don't support TypeScript natively

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/assertions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Eric L. Goldstein",
   "description": "TypeScript-based assertion functions to impose invariants",
   "engines": {

--- a/src/assertions.mts
+++ b/src/assertions.mts
@@ -19,7 +19,10 @@ function assert(
   assertionFailureCause?: unknown,
 ): asserts condition {
   if (!condition) {
-    throw new AssertionError(message, { cause: assertionFailureCause });
+    throw new AssertionError(
+      message,
+      assertionFailureCause ? { cause: assertionFailureCause } : undefined,
+    );
   }
 }
 

--- a/src/assertions.mts
+++ b/src/assertions.mts
@@ -9,12 +9,17 @@ class AssertionError extends Error {
 // Local Functions
 /**
  * Impose an invariant by verifying the provided condition is truthy, otherwise throw an `AssertionError`.
- * @param condition Condition to impose.
- * @param message   Error message to include as part of the thrown error.
+ * @param condition             Condition to impose.
+ * @param message               Error message to include as part of the thrown error.
+ * @param assertionFailureCause Any data that can help substantiate why this assertion failed.
  */
-function assert(condition: unknown, message = 'Assertion condition failure'): asserts condition {
+function assert(
+  condition: unknown,
+  message = 'Assertion condition failure', // eslint-disable-line default-param-last -- last 2 parameters are optional
+  assertionFailureCause?: unknown,
+): asserts condition {
   if (!condition) {
-    throw new AssertionError(message);
+    throw new AssertionError(message, { cause: assertionFailureCause });
   }
 }
 


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `1.3.0`
- Add an optional 3rd parameter to `assert()` to enable customizing the thrown error's `cause` field